### PR TITLE
fix manifest removing last entry

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 version_base=1.0
-version_patch=8
+version_patch=9

--- a/src/main/java/com/hypherionmc/modfusioner/actions/JarMergeAction.java
+++ b/src/main/java/com/hypherionmc/modfusioner/actions/JarMergeAction.java
@@ -594,7 +594,7 @@ public class JarMergeAction {
                     }
                     sb.append(line).append("\n");
                 }
-                FileUtils.write(file, sb.toString().trim(), StandardCharsets.UTF_8);
+                FileUtils.write(file, sb.toString(), StandardCharsets.UTF_8);
             }
         }
     }

--- a/src/main/java/com/hypherionmc/modfusioner/actions/JarMergeAction.java
+++ b/src/main/java/com/hypherionmc/modfusioner/actions/JarMergeAction.java
@@ -594,7 +594,7 @@ public class JarMergeAction {
                     }
                     sb.append(line).append("\n");
                 }
-                FileUtils.write(file, sb.toString(), StandardCharsets.UTF_8);
+                FileUtils.write(file, sb.toString().trim() + "\n", StandardCharsets.UTF_8);
             }
         }
     }


### PR DESCRIPTION
many text files (such as manifest.mf) require a trailing newline
so trust that files have whitespace at the end of the file for a reason.